### PR TITLE
Added ability to close on keyboard hit (default Escape)

### DIFF
--- a/jquery.reveal.js
+++ b/jquery.reveal.js
@@ -70,6 +70,9 @@
 				modalBG.css({"cursor":"pointer"})
 				modalBG.bind('click.modalEvent',closeModal)
 			}
+			$('body').keyup(function(e) {
+        		if(e.keyCode==27){ closeModal(); } // 27 is the keycode for the Escape key
+			});
 			
     		
 /*---------------------------


### PR DESCRIPTION
Hi Zurb!

I'm using reveal for a project and one of the requested features was to close on keyboard press.  I added a couple of lines that allows this; if you want, I can extend this into an option to allow the user to define which key, but I think Escape is a good default.

Thanks!
-Brian
