### PR TITLE
added a close event

### DIFF
--- a/jquery.reveal.js
+++ b/jquery.reveal.js
@@ -65,8 +65,12 @@
     		openModal();
 			
 			//Close Modal Listeners
-			var closeButton = $('.' + options.dismissmodalclass).bind('click.modalEvent',closeModal)
                         $(document).bind('reveal:close', closeModal);
+
+			var closeButton = $('.' + options.dismissmodalclass).bind('click.modalEvent', function() {
+				$(document).trigger('reveal:close');
+			});
+
 			if(options.closeonbackgroundclick) {
 				modalBG.css({"cursor":"pointer"})
 				modalBG.bind('click.modalEvent',closeModal)

--- a/jquery.reveal.js
+++ b/jquery.reveal.js
@@ -66,6 +66,7 @@
 			
 			//Close Modal Listeners
 			var closeButton = $('.' + options.dismissmodalclass).bind('click.modalEvent',closeModal)
+                        $(document).bind('reveal:close', closeModal);
 			if(options.closeonbackgroundclick) {
 				modalBG.css({"cursor":"pointer"})
 				modalBG.bind('click.modalEvent',closeModal)


### PR DESCRIPTION
Really not a dojo guy, but it looks like the functionality is already there in that version. Basically just watching for "reveal:close", and closing when its triggered. Can be triggered with `$(document).trigger('reveal:close');` Don't know if you guys wanted to do this some other way, but seems like the most simple solution.
