### PR TITLE
Trigger open and close events

### DIFF
--- a/jquery.reveal.js
+++ b/jquery.reveal.js
@@ -104,7 +104,8 @@
 						modal.css({'visibility' : 'visible', 'top':$(document).scrollTop()+topMeasure});
 						modalBG.css({"display":"block"});	
 						unlockModal()				
-					}   
+					}
+					modal.trigger('modalOpened');
 				}
 			}    	
 			
@@ -134,7 +135,8 @@
 					if(options.animation == "none") {
 						modal.css({'visibility' : 'hidden', 'top' : topMeasure});
 						modalBG.css({'display' : 'none'});	
-					}   			
+					}
+					modal.trigger('modalClosed'); 			
 				}
 			}
 			


### PR DESCRIPTION
Hi,

I needed to do something like the following so I added a couple event triggers.

$("theModal").bind('modalOpened',function(){
   // too distracting to have slideshow going in the background
   $('div.slideshow').slides('pause');
});

$("theModal").bind('modalClosed',function(){
   $('div.slideshow').slides('play');
});
