### PR TITLE
Added method to close modals.

### DIFF
--- a/jquery.reveal.js
+++ b/jquery.reveal.js
@@ -13,7 +13,12 @@
     var modalLocation = $(this).attr('data-reveal-id');
     $('#' + modalLocation).reveal($(this).data());
   });
-
+  
+  // Call jQuery.unreveal() or $.unreveal() to programatically hide modals.
+  $.fn.unreveal = function() {
+	  $('body').trigger({ type : 'keyup', which : 27 });
+  };
+  
   $.fn.reveal = function (options) {
     var defaults = {
       animation: 'fadeAndPop',                // fade, fadeAndPop, none


### PR DESCRIPTION
Added a quick callable method to close modals. It'll just send the "ESC" keystroke that the modals are listening for.

Usage: 

`````` jQuery.unreveal();```
or 
```$.unreveal();```
``````
