### PR TITLE
fire unlockModal() on callback

### DIFF
--- a/jquery.reveal.js
+++ b/jquery.reveal.js
@@ -46,14 +46,14 @@
             modal.delay(options.animationSpeed / 2).animate({
               "top": $(document).scrollTop() + topMeasure + 'px',
               "opacity": 1
-            }, options.animationSpeed, unlockModal());
+            }, options.animationSpeed, unlockModal;
           }
           if (options.animation == "fade") {
             modal.css({'opacity': 0, 'visibility': 'visible', 'top': $(document).scrollTop() + topMeasure});
             modalBg.fadeIn(options.animationSpeed / 2);
             modal.delay(options.animationSpeed / 2).animate({
               "opacity": 1
-            }, options.animationSpeed, unlockModal());
+            }, options.animationSpeed, unlockModal;
           }
           if (options.animation == "none") {
             modal.css({'visibility': 'visible', 'top': $(document).scrollTop() + topMeasure});


### PR DESCRIPTION
Hello,

I'm not sure whether or not it's a bug, but it looks like unlockModal() is actually being called immediately when starting the animation.  I found this out when trying to add some custom events ("reveal:opened" and "reveal:closed") to fire after the animations completed.

Cheers,
Michael
