### PR TITLE
Programmatic close action

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -38,10 +38,20 @@
 			None
 		</a>
 
+		<a href="#" class="big-link" onclick="$('#scriptedModal').reveal({ closeOnBackgroundClick: false })">
+			Open and Close With Script
+		</a>
+
 		<div id="myModal" class="reveal-modal">
 			<h1>Reveal Modal Goodness</h1>
 			<p>This is a default modal in all its glory, but any of the styles here can easily be changed in the CSS.</p>
 			<a class="close-reveal-modal">&#215;</a>
+		</div>
+
+		<div id="scriptedModal" class="reveal-modal">
+			<h1>Reveal Modal Goodness</h1>
+			<p>This is a default modal in all its glory, but any of the styles here can easily be changed in the CSS.</p>
+			<a href="#" onclick="$('#scriptedModal').closeReveal();return false;">Close</a>
 		</div>
 			
 	</body>

--- a/jquery.reveal.js
+++ b/jquery.reveal.js
@@ -123,4 +123,8 @@
       }
     });
   };
+
+  $.fn.closeReveal = function () {
+    $(this).trigger('reveal:close');
+  };
 })(jQuery);

--- a/jquery.reveal.js
+++ b/jquery.reveal.js
@@ -19,6 +19,7 @@
       animation: 'fadeAndPop',                // fade, fadeAndPop, none
       animationSpeed: 300,                    // how fast animtions are
       closeOnBackgroundClick: true,           // if you click background will modal close?
+      closeOnEscapeKey: true,                 // if you close on 'esc' key will modal close?
       dismissModalClass: 'close-reveal-modal' // the class of a button or element that will close an open modal
     };
     var options = $.extend({}, defaults, options);
@@ -108,11 +109,13 @@
         });
       }
 
-      $('body').keyup(function (event) {
-        if (event.which === 27) { // 27 is the keycode for the Escape key
-          modal.trigger('reveal:close');
-        }
-      });
+      if (options.closeOnEscapeKey) {
+        $('body').keyup(function (event) {
+          if (event.which === 27) { // 27 is the keycode for the Escape key
+            modal.trigger('reveal:close');
+          }
+        });
+      }
 
       function unlockModal() {
         locked = false;


### PR DESCRIPTION
You may object to the syntax of "closeReveal" – I didn't know if you'd prefer a separate JQuery method or not.

$('#myModal').reveal()
$('#myModal').closeReveal()
