### PR TITLE
Replaced .live() with .on()

### DIFF
--- a/jquery.reveal.js
+++ b/jquery.reveal.js
@@ -8,7 +8,7 @@
 
 
 (function ($) {
-  $('a[data-reveal-id]').live('click', function (event) {
+  $('a[data-reveal-id]').on('click', function (event) {
     event.preventDefault();
     var modalLocation = $(this).attr('data-reveal-id');
     $('#' + modalLocation).reveal($(this).data());


### PR DESCRIPTION
.live() was deprecated in jQuery 1.7 and replaced with .on().
