### PR TITLE
updates the JS for new jQuery versions (without .live)

### DIFF
--- a/jquery.reveal.js
+++ b/jquery.reveal.js
@@ -8,7 +8,7 @@
 
 
 (function ($) {
-  $('a[data-reveal-id]').live('click', function (event) {
+  $(document).on('click', 'a[data-reveal-id]', function(event) {
     event.preventDefault();
     var modalLocation = $(this).attr('data-reveal-id');
     $('#' + modalLocation).reveal($(this).data());


### PR DESCRIPTION
.live was deprecated and is now removed in jQuery. Now uses an event handler on the document.
