### PR TITLE
Updated jquery's "live" usage to "on"

### DIFF
--- a/jquery.reveal.js
+++ b/jquery.reveal.js
@@ -8,7 +8,7 @@
 
 
 (function ($) {
-  $('a[data-reveal-id]').live('click', function (event) {
+  $('a[data-reveal-id]').on('click', function (event) {
     event.preventDefault();
     var modalLocation = $(this).attr('data-reveal-id');
     $('#' + modalLocation).reveal($(this).data());


### PR DESCRIPTION
As of jQuery 1.9 "live" is no longer used to assign event handlers.  I've replaced "live" with "on" which is the proper usage.
