### PR TITLE
Unlocking modal when closed with no animation

### DIFF
--- a/jquery.reveal.js
+++ b/jquery.reveal.js
@@ -90,6 +90,7 @@
           if (options.animation == "none") {
             modal.css({'visibility': 'hidden', 'top': topMeasure});
             modalBg.css({'display': 'none'});
+            unlockModal();
           }
         }
         modal.unbind('reveal:close', closeAnimation);


### PR DESCRIPTION
A call to unlockModal() was missing in the closeAnimation in case the options.animation is set to none.
