### PR TITLE
Changed .live() to .on()

### DIFF
--- a/jquery.reveal.js
+++ b/jquery.reveal.js
@@ -8,7 +8,7 @@
 
 
 (function ($) {
-  $('a[data-reveal-id]').live('click', function (event) {
+  $('a[data-reveal-id]').on('click', function (event) {
     event.preventDefault();
     var modalLocation = $(this).attr('data-reveal-id');
     $('#' + modalLocation).reveal($(this).data());


### PR DESCRIPTION
.live() method is deprecated as of jQuery 1.7. Use .on() instead.
